### PR TITLE
Change contact form behaviour removing some "required=true"

### DIFF
--- a/collective/captchacontactinfo/browser/contact_form_view.py
+++ b/collective/captchacontactinfo/browser/contact_form_view.py
@@ -4,12 +4,11 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope import schema
 
 from Products.CMFPlone import PloneMessageFactory as _
+from collective.captchacontactinfo import captchacontactinfoMessageFactory as _C
 from Products.CMFPlone.browser.interfaces import IContactForm
 
 import logging
 import z3c.form.field
-from plone.autoform.form import AutoExtensibleForm
-
 from Acquisition import aq_inner
 from plone.formwidget.recaptcha.widget import ReCaptchaFieldWidget
 from z3c.form import button
@@ -51,6 +50,14 @@ class ContactInfoPolicy(ContactForm):
         fields = field.Fields(IReCaptchaForm)
         fields['captcha'].widgetFactory = ReCaptchaFieldWidget
         fields_objects = z3c.form.field.Fields(fields)
+        self.fields['sender_fullname'].field.required = False
+        self.fields['sender_from_address'].field.required = False
+        help_message = _C(
+            u'help_sender_from_address_customized',
+            default=u'Please enter your e-mail address if '
+            'you want to receive an answer')
+        self.fields['sender_from_address'].field.description = self.context.\
+            translate(help_message)
         self.fields += fields_objects
 
     @button.buttonAndHandler(_(u'label_send', default='Send'), name='send')
@@ -75,7 +82,8 @@ class ContactInfoPolicy(ContactForm):
         else:
             IStatusMessage(self.request).add(
                 self.formErrorsMessage,
-                type=u'The code you entered was wrong, please enter the new one.'
+                type=u'The code you entered was wrong, '
+                     'please enter the new one.'
             )
             return
 

--- a/collective/captchacontactinfo/locales/collective.captchacontactinfo.pot
+++ b/collective/captchacontactinfo/locales/collective.captchacontactinfo.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-18 15:24+0000\n"
+"POT-Creation-Date: 2018-01-30 11:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,20 +21,8 @@ msgstr ""
 msgid "Captcha Contact Info"
 msgstr ""
 
-#: ./configure.zcml:21
-msgid "Captcha contact-info"
-msgstr ""
-
-#: ./configure.zcml:21
-msgid "Installs the collective.captchacontactinfo package"
-msgstr ""
-
-#: ./browser/contact_form_view.py:73
+#: ./browser/contact_form_view.py:77
 msgid "ReCaptcha validation passed."
-msgstr ""
-
-#: ./configure.zcml:29
-msgid "Uninstalls the collective.captchacontactinfo package"
 msgstr ""
 
 #. Default: "Policy page"
@@ -62,8 +50,13 @@ msgstr ""
 msgid "heading_contact_form"
 msgstr ""
 
+#. Default: "Please enter your e-mail address if you want to receive an answer"
+#: ./browser/contact_form_view.py:55
+msgid "help_sender_from_address_customized"
+msgstr ""
+
 #. Default: "Send"
-#: ./browser/contact_form_view.py:56
+#: ./browser/contact_form_view.py:60
 msgid "label_send"
 msgstr ""
 
@@ -71,3 +64,4 @@ msgstr ""
 #: ./browser/templates/contact-info.pt:28
 msgid "text_no_email_setup"
 msgstr ""
+

--- a/collective/captchacontactinfo/locales/de/LC_MESSAGES/collective.captchacontactinfo.po
+++ b/collective/captchacontactinfo/locales/de/LC_MESSAGES/collective.captchacontactinfo.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-18 15:24+0000\n"
+"POT-Creation-Date: 2018-01-30 11:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Eggert Ehmke <eggert@eehmke.de>\n"
 "Language-Team: LANGUAGE <DE@de.org>\n"
@@ -21,20 +21,8 @@ msgstr ""
 msgid "Captcha Contact Info"
 msgstr ""
 
-#: ./configure.zcml:21
-msgid "Captcha contact-info"
-msgstr ""
-
-#: ./configure.zcml:21
-msgid "Installs the collective.captchacontactinfo package"
-msgstr ""
-
-#: ./browser/contact_form_view.py:73
+#: ./browser/contact_form_view.py:77
 msgid "ReCaptcha validation passed."
-msgstr ""
-
-#: ./configure.zcml:29
-msgid "Uninstalls the collective.captchacontactinfo package"
 msgstr ""
 
 #. Default: "Policy page"
@@ -62,8 +50,13 @@ msgstr ""
 msgid "heading_contact_form"
 msgstr ""
 
+#. Default: "Please enter your e-mail address if you want to receive an answer"
+#: ./browser/contact_form_view.py:55
+msgid "help_sender_from_address_customized"
+msgstr ""
+
 #. Default: "Send"
-#: ./browser/contact_form_view.py:56
+#: ./browser/contact_form_view.py:60
 msgid "label_send"
 msgstr ""
 
@@ -71,3 +64,4 @@ msgstr ""
 #: ./browser/templates/contact-info.pt:28
 msgid "text_no_email_setup"
 msgstr ""
+

--- a/collective/captchacontactinfo/locales/it/LC_MESSAGES/collective.captchacontactinfo.po
+++ b/collective/captchacontactinfo/locales/it/LC_MESSAGES/collective.captchacontactinfo.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-18 15:24+0000\n"
+"POT-Creation-Date: 2018-01-30 11:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,21 +21,9 @@ msgstr ""
 msgid "Captcha Contact Info"
 msgstr ""
 
-#: ./configure.zcml:21
-msgid "Captcha contact-info"
-msgstr ""
-
-#: ./configure.zcml:21
-msgid "Installs the collective.captchacontactinfo package"
-msgstr ""
-
-#: ./browser/contact_form_view.py:73
+#: ./browser/contact_form_view.py:77
 msgid "ReCaptcha validation passed."
 msgstr "Validazione ReCaptcha corretta"
-
-#: ./configure.zcml:29
-msgid "Uninstalls the collective.captchacontactinfo package"
-msgstr ""
 
 #. Default: "Policy page"
 #: ./controlpanel/interfaces.py:11
@@ -62,8 +50,13 @@ msgstr "Grazie per il tuo feedback"
 msgid "heading_contact_form"
 msgstr "Contatti"
 
+#. Default: "Please enter your e-mail address if you want to receive an answer"
+#: ./browser/contact_form_view.py:55
+msgid "help_sender_from_address_customized"
+msgstr "Inserisci il tuo indirizzo di posta elettronica se vuoi ricevere una risposta"
+
 #. Default: "Send"
-#: ./browser/contact_form_view.py:56
+#: ./browser/contact_form_view.py:60
 msgid "label_send"
 msgstr ""
 
@@ -71,3 +64,4 @@ msgstr ""
 #: ./browser/templates/contact-info.pt:28
 msgid "text_no_email_setup"
 msgstr "Prima di procedere occorre impostare la configurazione di Posta del sito"
+

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,10 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- fix contact form: for privacy reason remove obligatoriness
+  for sender name and sender email address; 
+  update message accordingly with previous topic
+  [lucabel]
 
 
 2.0.2 (2017-10-26)


### PR DESCRIPTION
fix contact form as customer request: for privacy reason remove obligatoriness for sender name and sender email address; update message accordingly